### PR TITLE
pcntl_alarm not getting reset when an exception is thrown

### DIFF
--- a/PHP/Invoker.php
+++ b/PHP/Invoker.php
@@ -82,7 +82,12 @@ class PHP_Invoker
         pcntl_signal(SIGALRM, array($this, 'callback'), TRUE);
         pcntl_alarm($timeout);
 
-        $result = call_user_func_array($callable, $arguments);
+        try {
+            $result = call_user_func_array($callable, $arguments);
+        } catch (Exception $e) {
+            pcntl_alarm(0);
+            throw $e;
+        }
 
         pcntl_alarm(0);
 


### PR DESCRIPTION
In general:

When a function is called that throws an exception the pcntl_alarm was not reset and so the TimeoutException was thrown later out of context.

For phpunit:

When a test is skipped the timeout is not reset because of `throw new PHPUnit_Framework_SkippedTestError` and that leads to the error popping up later, mostly during code coverage generation. 

Credit for the bug report and reproduce case that lead to me fixing it goes to @lstrojny
