### PR TITLE
Defer to PHPUnit's autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     },
     "autoload": {
         "files": [
-            "PHP/Invoker/Autoload.php"
         ]
     },
     "include-path": [

--- a/package-composer.json
+++ b/package-composer.json
@@ -11,7 +11,7 @@
         "irc": "irc://irc.freenode.net/phpunit"
     },
     "autoload": {
-        "files": [ "PHP/Invoker/Autoload.php" ]
+        "files": []
     },
     "include_path": [
         ""


### PR DESCRIPTION
PHPUnit's autoloader will load PHP Invoker's if present, avoid `require` versus `require_once` conflicts if Composer puts a `require` after a `require_once` has already been called.
