### PR TITLE
Tweaked travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: php
 
+dist: bionic
+
 php:
   - 7.3
   - 7.4
-
-before_install:
-  - composer self-update
-  - composer clear-cache
 
 install:
   - travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest
@@ -19,4 +17,3 @@ after_success:
 
 notifications:
   email: false
-


### PR DESCRIPTION
Travis already updates composer, and there is no cache to clear, since travis is not configured to cache the .composer folder. Also, it's best to pin the dist to avoid breaks when travis next changes the default.