### PR TITLE
Clear alarm in finally block

### DIFF
--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -56,16 +56,10 @@ final class Invoker
         pcntl_alarm($timeout);
 
         try {
-            $result = call_user_func_array($callable, $arguments);
-        } catch (Throwable $t) {
+            return call_user_func_array($callable, $arguments);
+        } finally {
             pcntl_alarm(0);
-
-            throw $t;
         }
-
-        pcntl_alarm(0);
-
-        return $result;
     }
 
     public function canInvokeWithTimeout(): bool


### PR DESCRIPTION
The pcntl_alarm can be cleared in a finally block. This results in simpler code as the exception must not be catched and re-thrown and the callable result must not be assigned to al local variable. 

Also added testcases to cover the alarm clearing. 
Relates to #2.